### PR TITLE
Add EnumerateToLevel

### DIFF
--- a/iptree/iptree_test.go
+++ b/iptree/iptree_test.go
@@ -163,6 +163,64 @@ func TestEnumerate(t *testing.T) {
 	}
 }
 
+func TestEnumerateToLevel(t *testing.T) {
+	var r *Tree
+	var n *net.IPNet
+
+	for p := range r.Enumerate() {
+		t.Errorf("Expected no nodes in empty tree but got at least one: %s", p)
+		break
+	}
+
+	r = NewTree()
+
+	_, n, _ = net.ParseCIDR("192.0.2.0/30")
+	r = r.InsertNet(n, "test 1.2")
+
+	_, n, _ = net.ParseCIDR("192.0.2.0/32")
+	r = r.InsertNet(n, "test 1.3")
+
+	_, n, _ = net.ParseCIDR("2001:db8::/32")
+	r = r.InsertNet(n, "test 2.1")
+
+	_, n, _ = net.ParseCIDR("192.0.2.0/24")
+	r = r.InsertNet(n, "test 1")
+
+	_, n, _ = net.ParseCIDR("2001:db8:1::/48")
+	r = r.InsertNet(n, "test 2.2")
+
+	_, n, _ = net.ParseCIDR("2001:db8:0:0:0:ff::/96")
+	r = r.InsertNet(n, "test 3")
+
+	_, n, _ = net.ParseCIDR("192.0.2.0/28")
+	r = r.InsertNet(n, "test 1.1")
+
+	items := []string{}
+	for p := range r.EnumerateToLevel(0) {
+		items = append(items, p.String())
+	}
+
+	s := strings.Join(items, ", ")
+	e := "192.0.2.0/24: \"test 1\", " +
+		"2001:db8::/32: \"test 2.1\""
+	if s != e {
+		t.Errorf("Expected following nodes %q but got %q", e, s)
+	}
+
+	items = []string{}
+	for p := range r.EnumerateToLevel(1) {
+		items = append(items, p.String())
+	}
+
+	s = strings.Join(items, ", ")
+	e = "192.0.2.0/24: \"test 1\", " +
+		"192.0.2.0/28: \"test 1.1\", " +
+		"2001:db8::/32: \"test 2.1\""
+	if s != e {
+		t.Errorf("Expected following nodes %q but got %q", e, s)
+	}
+}
+
 func TestGetByNet(t *testing.T) {
 	r := NewTree()
 

--- a/numtree/node32.go
+++ b/numtree/node32.go
@@ -103,6 +103,25 @@ func (n *Node32) Enumerate() chan *Node32 {
 	return ch
 }
 
+// Enumerate returns channel which is populated by nodes with data in order of their keys (down to the target level only)
+func (n *Node32) EnumerateToLevel(targetLevel int) chan *Node32 {
+	ch := make(chan *Node32)
+
+	go func() {
+		defer close(ch)
+
+		// If tree is empty -
+		if n == nil {
+			// return nothing.
+			return
+		}
+
+		n.enumerateToLevel(0, targetLevel, ch)
+	}()
+
+	return ch
+}
+
 // Match locates node which key is equal to or "contains" the key passed as argument.
 func (n *Node32) Match(key uint32, bits int) (interface{}, bool) {
 	// If tree is empty -
@@ -302,6 +321,25 @@ func (n *Node32) enumerate(ch chan *Node32) {
 
 	if n.chld[1] != nil {
 		n.chld[1].enumerate(ch)
+	}
+}
+
+func (n *Node32) enumerateToLevel(level, targetLevel int, ch chan *Node32) {
+	// Implemented by depth-first search.
+	if n.Leaf {
+		ch <- n
+	}
+
+	if level == targetLevel {
+		return
+	}
+
+	if n.chld[0] != nil {
+		n.chld[0].enumerateToLevel(level+1, targetLevel, ch)
+	}
+
+	if n.chld[1] != nil {
+		n.chld[1].enumerateToLevel(level+1, targetLevel, ch)
 	}
 }
 

--- a/numtree/node32_test.go
+++ b/numtree/node32_test.go
@@ -187,6 +187,24 @@ func TestEnumerate32(t *testing.T) {
 		"0xabaaaaaa/9: \"L2.2\"")
 }
 
+func TestEnumerate32ToLevel(t *testing.T) {
+	var r *Node32
+
+	ch := r.Enumerate()
+	assertSequence32(ch, t, "32-tree empty tree")
+
+	r = r.Insert(0xAAAAAAAA, 7, "L1")
+	r = r.Insert(0xA8AAAAAA, 9, "L2.1")
+	r = r.Insert(0xABAAAAAA, 9, "L2.2")
+	r = r.Insert(0xAAAAAAAA, 18, "L3")
+	r = r.Insert(0xAAABAAAA, 24, "L5")
+	r = r.Insert(0xAABAAAAA, 19, "L4")
+	ch = r.EnumerateToLevel(1)
+	assertSequence32(ch, t, "32-tree for enumeration",
+		"0xa8aaaaaa/9: \"L2.1\"",
+		"0xaaaaaaaa/7: \"L1\"")
+}
+
 func TestMatch32(t *testing.T) {
 	var r *Node32
 
@@ -348,6 +366,7 @@ func assertTree32(r *Node32, e, desc string, t *testing.T) {
 }
 
 func assertSequence32(ch chan *Node32, t *testing.T, desc string, e ...string) {
+	t.Helper()
 	items := []string{}
 	for n := range ch {
 		if n == nil {
@@ -374,6 +393,7 @@ func assertSequence32(ch chan *Node32, t *testing.T, desc string, e ...string) {
 }
 
 func assertStringLists(v, e []string, desc string, t *testing.T) {
+	t.Helper()
 	ctx := difflib.ContextDiff{
 		A:        e,
 		B:        v,

--- a/numtree/node64.go
+++ b/numtree/node64.go
@@ -105,6 +105,23 @@ func (n *Node64) Enumerate() chan *Node64 {
 	return ch
 }
 
+// Enumerate returns channel which is populated by nodes in order of their keys (down to the target level only).
+func (n *Node64) EnumerateToLevel(targetLevel int) chan *Node64 {
+	ch := make(chan *Node64)
+
+	go func() {
+		defer close(ch)
+
+		if n == nil {
+			return
+		}
+
+		n.enumerateToLevel(0, targetLevel, ch)
+	}()
+
+	return ch
+}
+
 // Match locates node which key is equal to or "contains" the key passed as argument.
 func (n *Node64) Match(key uint64, bits int) (interface{}, bool) {
 	if n == nil {
@@ -273,6 +290,24 @@ func (n *Node64) enumerate(ch chan *Node64) {
 
 	if n.chld[1] != nil {
 		n.chld[1].enumerate(ch)
+	}
+}
+
+func (n *Node64) enumerateToLevel(level, targetLevel int, ch chan *Node64) {
+	if n.Leaf {
+		ch <- n
+	}
+
+	if level == targetLevel {
+		return
+	}
+
+	if n.chld[0] != nil {
+		n.chld[0].enumerateToLevel(level+1, targetLevel, ch)
+	}
+
+	if n.chld[1] != nil {
+		n.chld[1].enumerateToLevel(level+1, targetLevel, ch)
 	}
 }
 

--- a/numtree/node64_test.go
+++ b/numtree/node64_test.go
@@ -187,6 +187,24 @@ func TestEnumerate64(t *testing.T) {
 		"0xabaaaaaa00000000/9: \"L2.2\"")
 }
 
+func TestEnumerate64ToLevel(t *testing.T) {
+	var r *Node64
+
+	ch := r.Enumerate()
+	assertSequence64(ch, t, "64-tree empty tree")
+
+	r = r.Insert(0xAAAAAAAA00000000, 7, "L1")
+	r = r.Insert(0xA8AAAAAA00000000, 9, "L2.1")
+	r = r.Insert(0xABAAAAAA00000000, 9, "L2.2")
+	r = r.Insert(0xAAAAAAAA00000000, 18, "L3")
+	r = r.Insert(0xAAABAAAA00000000, 24, "L5")
+	r = r.Insert(0xAABAAAAA00000000, 19, "L4")
+	ch = r.EnumerateToLevel(1)
+	assertSequence64(ch, t, "64-tree for enumeration",
+		"0xa8aaaaaa00000000/9: \"L2.1\"",
+		"0xaaaaaaaa00000000/7: \"L1\"")
+}
+
 func TestMatch64(t *testing.T) {
 	var r *Node64
 


### PR DESCRIPTION
This work adds the ability to enumerate to a certain level of nodes in the tree. Useful if you want to get the top level nodes, closest to the root.