### PR TITLE
Canonicalize IPv4 addresses

### DIFF
--- a/iptree/iptree.go
+++ b/iptree/iptree.go
@@ -361,7 +361,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -370,7 +371,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/iptree/iptree_test.go
+++ b/iptree/iptree_test.go
@@ -818,8 +818,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}

--- a/uintX/iptree16/iptree.go
+++ b/uintX/iptree16/iptree.go
@@ -217,7 +217,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -226,7 +227,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/uintX/iptree16/iptree_test.go
+++ b/uintX/iptree16/iptree_test.go
@@ -299,8 +299,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}

--- a/uintX/iptree32/iptree.go
+++ b/uintX/iptree32/iptree.go
@@ -217,7 +217,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -226,7 +227,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/uintX/iptree32/iptree_test.go
+++ b/uintX/iptree32/iptree_test.go
@@ -299,8 +299,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}

--- a/uintX/iptree64/iptree.go
+++ b/uintX/iptree64/iptree.go
@@ -217,7 +217,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -226,7 +227,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/uintX/iptree64/iptree_test.go
+++ b/uintX/iptree64/iptree_test.go
@@ -299,8 +299,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}

--- a/uintX/iptree8/iptree.go
+++ b/uintX/iptree8/iptree.go
@@ -217,7 +217,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -226,7 +227,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/uintX/iptree8/iptree_test.go
+++ b/uintX/iptree8/iptree_test.go
@@ -299,8 +299,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}

--- a/uintX/iptree{{.bits}}/iptree.{{.ext}}
+++ b/uintX/iptree{{.bits}}/iptree.{{.ext}}
@@ -217,7 +217,8 @@ func (t *Tree) enumerate(ch chan Pair) {
 }
 
 func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
-	if len(n.IP) != net.IPv4len {
+	ip := n.IP.To4()
+	if ip == nil {
 		return 0, -1
 	}
 
@@ -226,7 +227,7 @@ func iPv4NetToUint32(n *net.IPNet) (uint32, int) {
 		return 0, -1
 	}
 
-	return packIPToUint32(n.IP), ones
+	return packIPToUint32(ip), ones
 }
 
 func packIPToUint32(x net.IP) uint32 {

--- a/uintX/iptree{{.bits}}/iptree_test.{{.ext}}
+++ b/uintX/iptree{{.bits}}/iptree_test.{{.ext}}
@@ -299,8 +299,13 @@ func TestTreeByIP(t *testing.T) {
 }
 
 func TestIPv4NetToUint32(t *testing.T) {
+	key, bits := iPv4NetToUint32(&net.IPNet{IP: net.IPv4zero, Mask: iPv4MaxMask})
+	if key != 0 || bits != 32 {
+		t.Errorf("Expected 0x0, 32 pair but got 0x%08x, %d", key, bits)
+	}
+
 	_, n, _ := net.ParseCIDR("192.0.2.0/24")
-	key, bits := iPv4NetToUint32(n)
+	key, bits = iPv4NetToUint32(n)
 	if key != 0xc0000200 || bits != 24 {
 		t.Errorf("Expected 0xc0000200, 24 pair but got 0x%08x, %d", key, bits)
 	}


### PR DESCRIPTION
This fixes an issue where non-canonicalized IPv4 addresses could not be used in trees (16-byte arrays containing an ipv4 address, the default format for all IPv4 constants from the `net` package).